### PR TITLE
Add GitHub actions for maven builds

### DIFF
--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven build - MacOS latest
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: '14.0.1'
+    - name: Build with Maven
+      run: mvn -e clean test --file pom.xml

--- a/.github/workflows/maven_ubuntu.yml
+++ b/.github/workflows/maven_ubuntu.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven build - Ubuntu latest
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: '14.0.1'
+    - name: Build with Maven
+      run: mvn -e clean test --file pom.xml

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven build - Windows latest
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: '14.0.1'
+    - name: Build with Maven
+      run: mvn -e clean test --file pom.xml


### PR DESCRIPTION
## Description
Add github actions for Maven builds in MAC OS X, Windows, Linux (Ubuntu).

Fixes #7.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
      Not applicable.
- [x] **All methods have documentation comments.**
      Not applicable.
- [x] **No parameters are hardcoded.**
      N/A as reading from properties is not currently supported.
- [x] **All information to be logged/displayed to the user are internationalized.**
      N/A as internationalization is not currently supported.
- [x] **README.md has been updated if needed.**
      Not applicable.

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
      Not actions configured yet.
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
      Not applicable.