### PR TITLE
Added an action to publish to GitHub packages

### DIFF
--- a/.github/workflows/package_publish.yml
+++ b/.github/workflows/package_publish.yml
@@ -1,0 +1,31 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
+
+name: Publish to GitHub packages
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checkout submodules
+          run: git submodule update --init --recursive
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: '14.0.1'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Publish to GitHub Packages Apache Maven
+        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Description
Add a GitHub action to add a jar to the GitHub packages during a release.

Closes #8.

## Author's Checklist
- [x] **These changes don't break existing dependants.**

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
      Not applicable.
- [x] **All methods have documentation comments.**
      Not applicable.
- [x] **No parameters are hardcoded.**
      N/A as reading from properties is not currently supported.
- [x] **All information to be logged/displayed to the user are internationalized.**
      N/A as internationalization is not currently supported.
- [x] **README.md has been updated if needed.**
      Not needed.

## Assignee's Checklist
- [ ] **All GitHub action checks have passed.**
      Not applicable.
- [ ] **All reviewers have approved.**
- [ ] **Relevant documentation has been updated if needed.**
      Not applicable.