### PR TITLE
Add README.md template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+<div align="center">
+  <h1 align="center">Project Name</h1>
+  <p align="center">
+    A template for Java maven projects.
+    <br />
+    <a href="https://github.com/padaiyal/jMavenProjectTemplate/issues/new/choose">Report Bug/Request Feature</a>
+  </p>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![Apache License][license-shield]][license-url] <br>
+![Maven build - Ubuntu latest](https://github.com/padaiyal/jMavenProjectTemplate/workflows/Maven%20build%20-%20Ubuntu%20latest/badge.svg?branch=main)
+![Maven build - Windows latest](https://github.com/padaiyal/jMavenProjectTemplate/workflows/Maven%20build%20-%20Windows%20latest/badge.svg?branch=main)
+![Maven build - MacOS latest](https://github.com/padaiyal/jMavenProjectTemplate/workflows/Maven%20build%20-%20MacOS%20latest/badge.svg?branch=main)
+
+</div>
+
+<!--
+*** To avoid retyping too much info. Do a search and replace with your text editor for the following:
+    'jMavenProjectTemplate'
+ -->
+
+<!-- TABLE OF CONTENTS -->
+<details open="open">
+  <summary>Table of Contents</summary>
+  <ol>
+    <li>
+      <a href="#about-the-project">About The Project</a>
+    </li>
+    <li>
+        <a href="#usage">Usage</a>
+    </li>
+    <li>
+        <a href="#roadmap">Roadmap</a>
+    </li>
+    <li>
+        <a href="#contributing">Contributing</a>
+    </li>
+    <li>
+        <a href="#license">License</a>
+    </li>
+  </ol>
+</details>
+
+<!-- ABOUT THE PROJECT -->
+## About The Project
+Describe the project.
+
+<!-- USAGE -->
+## Usage
+Specify the steps to set up and use the project.
+
+<!-- ROADMAP -->
+## Roadmap
+See the [open issues](https://github.com/padaiyal/jMavenProjectTemplate/issues) for a list of proposed features (and known issues).
+
+<!-- CONTRIBUTING -->
+## Contributing
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the Project.
+2. Create your branch. (`git checkout -b contribution/AmazingContribution`)
+3. Commit your changes. (`git commit -m 'Add some AmazingContribution'`)
+4. Push to the branch. (`git push origin contribution/AmazingContribution`)
+5. Open a Pull Request.
+
+
+<!-- LICENSE -->
+## License
+Distributed under the Apache License. See [`LICENSE`](https://github.com/padaiyal/jMavenProjectTemplate/blob/main/LICENSE) for more information.
+
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+[contributors-shield]: https://img.shields.io/github/contributors/padaiyal/jMavenProjectTemplate.svg?style=for-the-badge
+[contributors-url]: https://github.com/padaiyal/jMavenProjectTemplate/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/padaiyal/jMavenProjectTemplate.svg?style=for-the-badge
+[forks-url]: https://github.com/padaiyal/jMavenProjectTemplate/network/members
+[stars-shield]: https://img.shields.io/github/stars/padaiyal/jMavenProjectTemplate.svg?style=for-the-badge
+[stars-url]: https://github.com/padaiyal/jMavenProjectTemplate/stargazers
+[issues-shield]: https://img.shields.io/github/issues/padaiyal/jMavenProjectTemplate.svg?style=for-the-badge
+[issues-url]: https://github.com/padaiyal/jMavenProjectTemplate/issues
+[license-shield]: https://img.shields.io/github/license/padaiyal/jMavenProjectTemplate.svg?style=for-the-badge
+[license-url]: https://github.com/padaiyal/jMavenProjectTemplate/blob/master/LICENSE.txt


### PR DESCRIPTION
## Description
Add README.md template to be used by Maven Projects.

Fixes #2.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
      Not applicable.
- [x] **All methods have documentation comments.**
      Not applicable.
- [x] **No parameters are hardcoded.**
      N/A as reading from properties is not currently supported.
- [x] **All information to be logged/displayed to the user are internationalized.**
      N/A as internationalization is not currently supported.
- [x] **README.md has been updated if needed.**
      
## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**