### PR TITLE
Cache the local maven repositories in the GitHub action runners

### DIFF
--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -22,5 +22,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '14.0.1'
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: mvn -e clean test --file pom.xml

--- a/.github/workflows/maven_ubuntu.yml
+++ b/.github/workflows/maven_ubuntu.yml
@@ -22,5 +22,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '14.0.1'
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: mvn -e clean test --file pom.xml

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -22,5 +22,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: '14.0.1'
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: mvn -e clean test --file pom.xml


### PR DESCRIPTION

## Description
Closes #23.
This will help speed up maven related tasks by caching dependant
repositories.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
       N/A
- [x] **All methods have documentation comments.**
       N/A
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
       N/A
- [x] **All information to be logged/displayed to the user are internationalized.** If not, explain why. 
       N/A
- [x] **README.md has been updated if needed.**
       N/A

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**