### PR TITLE
Removed line breaks for each section in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,25 +6,25 @@ labels: 'bug'
 assignees: ' '
 ---
 
-- [ ] <b>Description</b> <br>
+- [ ] <b>Description</b>
     A clear and concise description of what the bug is. <br>
-- [ ] <b>Affected platforms</b> <br>
+- [ ] <b>Affected platforms</b>
 
     | OS      	| Version 	|
     |---------	|---------	|
     | Windows 	| 10      	|
     | Ubuntu  	| 20.04   	|
     | ...     	| ...     	|
-- [ ] <b>Reproduction steps</b> <br>
+- [ ] <b>Reproduction steps</b>
     Steps to reproduce the behavior:
     1. Go to '...'
     2. Click on '....'
     3. Scroll down to '....'
     4. See error <br>
     Attach reproduction code if applicable.
-- [ ] <b>Expected behavior</b> <br>
+- [ ] <b>Expected behavior</b>
     A clear and concise description of what you expected to happen.
-- [ ] <b>Screenshots</b> <br>
+- [ ] <b>Screenshots</b>
     If applicable, add screenshots to help explain your problem.
-- [ ] <b>Additional information</b> <br>
+- [ ] <b>Additional information</b>
     Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_or_enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_or_enhancement_request.md
@@ -6,19 +6,19 @@ labels: ' '
 assignees: ' '
 ---
 
-- [ ] <b>Description</b> <br>
+- [ ] <b>Description</b>
     A clear and concise description of request/enhancement. <br>
-- [ ] <b>Use cases</b> <br>
+- [ ] <b>Use cases</b>
     1. Save the world.
     2. Stop the imposter.
     3. .... <br>
-- [ ] <b>Proposed design</b> <br>
+- [ ] <b>Proposed design</b>
     A clear and concise description of the design planned for this feature/enhancement.
     Attach design diagrams if applicable.
-- [ ] <b>Alternative design approaches</b> <br>
+- [ ] <b>Alternative design approaches</b>
     A list of other approaches that could've been taken to design this feature/enhancement, 
     but hasn't been because of a specified reason.
-- [ ] <b>Workaround</b> <br>
+- [ ] <b>Workaround</b>
     If any workaround exists to achieve the desired goal without this feature/enhancement.
-- [ ] <b>Additional information</b> <br>
+- [ ] <b>Additional information</b>
     Add any other context about the problem here.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>maven-project-template</artifactId>
-  <version>2021.01.13</version>
+  <version>2021.01.15</version>
 
   <parent>
     <groupId>org.padaiyal</groupId>


### PR DESCRIPTION
## Description
Remove line breaks for each section in issue templates.
Closes #34.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
      N/A
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
      N/A
- [x] **All information to be logged/displayed to the user are internationalized.** If not, explain why. 
      N/A
- [x] **README.md has been updated if needed.**
      N/A
- [x] **pom.xml version is set to the latest date** If not, explain why.

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
- [x] **pom.xml version is set to the latest date** If not, explain why.