### PR TITLE
Update jPopper dependency to latest version.

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -32,4 +32,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
-      run: mvn -e clean test verify --file pom.xml
+      run: mvn -e -"Dgpg.skip" clean test verify --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,14 @@
   <modelVersion>4.0.0</modelVersion>
  
   <!-- Update the following three entries -->
-  <groupId>org.padaiyal</groupId>
+  <groupId>io.github.padaiyal</groupId>
   <artifactId>mavenprojecttemplate</artifactId>
-  <version>2021.06.22</version>
+  <version>2021.12.31</version>
 
   <parent>
-    <groupId>org.padaiyal</groupId>
+    <groupId>io.github.padaiyal</groupId>
     <artifactId>popper</artifactId>
-    <version>2021.01.22</version>
-    <relativePath>jPopper</relativePath>
+    <version>2021.12.19</version>
   </parent>
 
   <distributionManagement>


### PR DESCRIPTION
## Description
Closes #51.
Update jPopper dependency to latest version 2021.12.19 from Maven Central.
Skipped signing of package as PRs from forks will not have access to the
necessary organization secrets (private key and key password).

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** N/A
- [ ] **All methods have documentation comments.** N/A
- [ ] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why. N/A
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why. N/A
- [ ] **README.md has been updated if needed.** N/A
- [x] **pom.xml version is set to the latest date** If not, explain why.

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [ ] **Relevant documentation has been updated if needed.** N/A
- [x] **pom.xml version is set to the latest date** If not, explain why.